### PR TITLE
Collision Template Detection

### DIFF
--- a/src/yass/deconvolve/collision.py
+++ b/src/yass/deconvolve/collision.py
@@ -167,5 +167,7 @@ def collision_templates(templates, get_unit_spike_fun):
     mad_collision_picks = np.setdiff1d(
             mad_collision_picks, np.array(elemental))
 
-    return deconv_collision_picks, mad_collision_picks
+    return np.union1d(
+            np.array(deconv_collision_picks),
+            np.array(mad_collision_picks))
 

--- a/src/yass/deconvolve/collision.py
+++ b/src/yass/deconvolve/collision.py
@@ -1,0 +1,171 @@
+"""Tools for detecting collision templates."""
+
+import copy as copy
+import numpy as np
+from tqdm import tqdm
+
+from optimized_match_pursuit import OptimizedMatchPursuit
+from template import WaveForms
+
+
+def MAD_bernoulli_two_uniforms(a, b):
+    """Analytical MAD of a addition of uniform drawn according to Bernoulli rv.
+
+    i ~ Bernoulli(0.5)
+    x ~ uniform(0., a)
+    y ~ uniform(0., b)
+    z = ix + (1-i)y
+    This functions computes the analytical median absolute deviation
+    of the resulting z random variable.
+
+    params:
+    -------
+    a: int or np.ndarray
+    b: int or np.ndarray
+
+    returns:
+    --------
+    float or np.ndarray
+    """
+    same_sign_indicator = np.array(a * b > 0.).astype(np.float)
+    a, b = np.abs(a), np.abs(b)
+    # Make sure that a , b on all elements of the arrays
+    concat = np.array([a, b])
+    a, b = concat.min(axis=0), concat.max(axis=0)
+    # Median of the random variable
+    a_inv, b_inv = 1. / a, 1. / b
+    a_inv_plus_b_inv = a_inv + b_inv
+    m = 1. / a_inv_plus_b_inv
+    t1 = (a - m) * a_inv_plus_b_inv
+    t2 = (2 * m - a) * (a_inv / 2. + b_inv)
+    # remainder is t3 = (b - 2*m) * 1/b / 2. where t1 + t2 + t3 = 1
+
+    # handle two where t1 less than or greater than 0.5
+    indicator = np.array(t1 > 0.5).astype(np.float)
+    opt1 = (.5 / t1) * (a - m)
+    opt2 = (a - m) + (0.5 - t1) / t2 * (2 * m - a)
+    out = indicator * opt1 + (1 - indicator) * opt2
+    # handle two cases where a and b have different signs
+    return same_sign_indicator * out + (1 - same_sign_indicator) * m
+
+
+def collision_templates(templates, get_unit_spike_fun):
+    """Given templates and spikes determines collision templates.
+
+    params:
+    -------
+    templates: np.ndarray
+        Has shape (# units, # channels, # number of time samples).
+
+    returns:
+    --------
+    tuple of np.array. First is list of unit ids that are determined to be
+    collisions using deconvolution. Second, is the list of unit ids that
+    have unexpected MAD values.
+    """
+    n_unit, n_chan, n_time = templates.shape
+
+    # First step is to deconvolve given templates using the rest of them.
+    # This steps gets rid of templates that are reconstructed very well using
+    # the rest.
+
+    # Stack all the templates temporally given enough space between them.
+    data = np.zeros([n_time * 2 * n_unit, n_chan])
+    tot_time = data.shape[0]
+    spike_times = np.arange(n_time // 2, tot_time, n_time * 2) + 10
+    for unit, time in enumerate(spike_times):
+        data[time:time + n_time, :] += templates[unit].T
+    mp = OptimizedMatchPursuit(
+            data, templates.transpose([2, 1, 0]), threshold=0,
+            conv_approx_rank=10, vis_su=1., upsample=16, keep_iterations=True)
+    mp.compute_objective()
+    # Before the subtraction step of match-pusuit guarantee that no template
+    # is deconvolved with itself.
+    for unit, time in enumerate(spike_times):
+        time = time + n_time // 2
+        mp.obj[unit, time:time + n_time] = - np.inf
+
+    deconvd_sp, dist_metric = mp.run(max_iter=2)
+    otemps = mp.get_upsampled_templates()
+    ospt = mp.correct_shift_deconv_spike_train()
+
+
+    residual = copy.copy(data)
+    for up_unit in np.unique(ospt[:, 1]):
+        # Get spike times
+        unit_spt = ospt[ospt[:, 1] == up_unit, :1]
+        residual[np.arange(n_time) + unit_spt, :] -= otemps[:, :, up_unit]
+
+    unit_residuals = []
+    unit_factors = []
+    for unit in tqdm(range(n_unit), "Computing Residuals"):
+        time = spike_times[unit]
+        factor_times = np.logical_and(
+                ospt[:, 0] > time - n_time, ospt[:, 0] < time + n_time)
+        factor = ospt[factor_times, 1]
+        # Convert upsample id to original template/unit id.
+        factor = factor // 16
+        unit_factors.append(factor)
+        window = 10
+        spike_res = residual[time+window:time+n_time-window] 
+        unit_residuals.append(spike_res)
+
+    unit_residuals = np.array(unit_residuals)
+    res_max_norm = np.abs(unit_residuals).max(axis=-1).max(axis=-1)
+    # Get those templates that have residual max norm of no more that 1.
+    # as collision templates.
+    candidates = np.where(res_max_norm < 1.)[0]
+
+    # Keep track of elemental units necessary to reconstruct collision
+    # templates.
+    elemental = []
+    deconv_collision_picks = []
+    for unit in candidates:
+        if unit not in elemental:
+            deconv_collision_picks.append(unit)
+            for e in unit_factors[unit]:
+                if e not in elemental:
+                    elemental.append(e)
+
+    # Second Stage: use MAD statistics of unit wave forms to detect
+    # Collision templates.
+    unit_mads = []
+    # Analytical AMD if noise of spike is only uniform jitters. This
+    # serves as a lower bound for the actual MAD.
+    unit_emads = []
+
+    # Jitter for alignments for spike wave forms.
+    jitter = 3
+    visch = (templates.ptp(axis=-1) > 2.)
+    for unit in tqdm(range(n_unit), "Computing MAD"):
+        wf = get_unit_spike_fun(unit)
+        wf = wf[:, visch[unit], :]
+        mean = wf.mean(axis=0)
+        # Compute the approximate expected MAD of normali looking spikes.
+        wf = WaveForms(wf).align(jitter=jitter)
+        # Clipp the mean so that it is the same shape as the aligned
+        # waveforms.
+        mean_clipped = mean[:, jitter:-jitter]
+        delta_minus = np.abs(mean_clipped - mean[:, jitter-1:-jitter-1])
+        delta_plus = np.abs(mean_clipped - mean[:, jitter+1:-jitter+1])
+
+        emad = MAD_bernoulli_two_uniforms(delta_minus, delta_plus)
+        unit_emads.append(emad)
+
+        t_mad = np.median(
+                np.abs(np.median(wf, axis=0)[None, :, :] - wf), axis=0)
+        unit_mads.append(t_mad)
+
+    # Count total number of unexpectedly large MAD values per unit.
+    high_mad_counts = []
+    for unit in range(n_unit):
+        high_mad_counts.append(
+                ((unit_mads[unit] - unit_emads[unit]) > 0.8).sum())
+    high_mad_counts = np.array(high_mad_counts)
+    mad_collision_picks = np.where(high_mad_counts > 3)[0]
+    # remove elemental units
+    mad_collision_picks = np.setdiff1d(
+            mad_collision_picks, np.array(elemental))
+
+    return deconv_collision_picks, mad_collision_picks
+

--- a/src/yass/deconvolve/collision.py
+++ b/src/yass/deconvolve/collision.py
@@ -4,8 +4,8 @@ import copy as copy
 import numpy as np
 from tqdm import tqdm
 
-from optimized_match_pursuit import OptimizedMatchPursuit
-from template import WaveForms
+from yass.deconvolve.optimized_match_pursuit import OptimizedMatchPursuit
+from yass.deconvolve.template import WaveForms
 
 
 def MAD_bernoulli_two_uniforms(a, b):

--- a/src/yass/deconvolve/deconv_exp_utils.py
+++ b/src/yass/deconvolve/deconv_exp_utils.py
@@ -174,8 +174,8 @@ def plot_spatial_fill(geom, temp, ax, color='C0', scale=10., squeeze=8.):
     for c in range(temp.shape[1]):
         ax.fill_between(
             np.arange(0, leng, 1) / squeeze + geom[c, 0],
-            temp_[:, c] - scale / 2  + geom[c, 1],
-            temp_[:, c] + scale / 2 + geom[c, 1], color=color, alpha=0.3)
+            temp_[:, c] - scale + geom[c, 1],
+            temp_[:, c] + scale + geom[c, 1], color=color, alpha=0.2)
 
 
 def plot_chan_numbers(geom, ax, offset=10):

--- a/src/yass/deconvolve/optimized_match_pursuit.py
+++ b/src/yass/deconvolve/optimized_match_pursuit.py
@@ -1,7 +1,6 @@
 import copy
 import numpy as np
 import scipy
-import matplotlib.pyplot as plt
 
 
 class OptimizedMatchPursuit(object):

--- a/src/yass/deconvolve/optimized_match_pursuit.py
+++ b/src/yass/deconvolve/optimized_match_pursuit.py
@@ -430,8 +430,8 @@ class OptimizedMatchPursuit(object):
         self.compute_objective()
         while tot_max > self.threshold and ctr < max_iter:
             spt, dist_met = self.find_peaks()
-            print "Iteration {0} Found {1} spikes with {2:.2f} energy reduction.".format(
-                ctr, spt.shape[0], np.sum(dist_met))
+            print("Iteration {0} Found {1} spikes with {2:.2f} energy reduction.".format(
+                ctr, spt.shape[0], np.sum(dist_met)))
             if len(spt) == 0:
                 break
             self.dec_spike_train = np.append(self.dec_spike_train, spt, axis=0)

--- a/src/yass/deconvolve/optimized_match_pursuit.py
+++ b/src/yass/deconvolve/optimized_match_pursuit.py
@@ -1,0 +1,445 @@
+import copy
+import numpy as np
+import scipy
+import matplotlib.pyplot as plt
+
+
+class OptimizedMatchPursuit(object):
+    """Class for doing greedy matching pursuit deconvolution."""
+
+    def __init__(self, data, temps, refrac_period=20, threshold=2.,
+            conv_approx_rank=3, upsample=1, vis_su=2., keep_iterations=False):
+        """Sets up the deconvolution object.
+
+        Parameters:
+        -----------
+        data: numpy array of shape (T, C)
+            Where T is number of time samples and C number of channels.
+        temps: numpy array of shape (t, C, K)
+            Where t is number of time samples and C is the number of
+            channels and K is total number of units.
+        conv_approx_rank: int
+            Rank of SVD decomposition for approximating convolution
+            operations for templates.
+        threshold: float
+            amount of energy differential that is admissible by each
+            spike. The lower this threshold, more spikes are recovered.
+        upsample: int
+            Upsampling factor to be used for fitting templates. If 1, no
+            upsampling is done. If non-positive, dynamic upsampling will be used.
+        vis_su: float
+            threshold for visibility of template channel in terms
+            of peak to peak standard unit.
+        keep_iterations: boolean
+            Keeps the spike train per iteration if True. Otherwise,
+            does not keep the history.
+        """
+        self.n_time, self.n_chan, self.n_unit = temps.shape
+        self.temps = temps.astype(np.float32)
+        self.orig_temps = temps.astype(np.float32)
+        # Dynamic Upsampling Setup.
+        if upsample < 1:
+            self.unit_up_factor = np.power(
+                    2, np.floor(np.log2(np.max(temps.ptp(axis=0), axis=0))))
+            self.up_factor = min(32, int(np.max(self.unit_up_factor)))
+            self.unit_up_factor[self.unit_up_factor > 32] = 32
+            self.up_up_map = np.zeros(
+                    self.n_unit * self.up_factor, dtype=np.int32)
+            for i in range(self.n_unit):
+                u_idx = i * self.up_factor
+                u_factor = self.unit_up_factor[i]
+                skip = self.up_factor // u_factor
+                self.up_up_map[u_idx:u_idx + self.up_factor] = u_idx  + np.arange(
+                        0, self.up_factor, skip).repeat(skip)
+        else:
+            # Upsample and downsample time shifted versions
+            self.up_factor = upsample
+            self.up_up_map = range(self.n_unit * self.up_factor)
+        self.threshold = threshold
+        self.approx_rank = conv_approx_rank
+        self.vis_su_threshold = vis_su
+        self.vis_chan = None
+        self.visible_chans()
+        self.template_overlaps()
+        self.spatially_mask_templates()
+        # Upsample the templates
+        # Index of the original templates prior to
+        # upsampling them.
+        self.orig_n_unit = self.n_unit
+        self.n_unit = self.orig_n_unit * self.up_factor
+        self.orig_template_idx = np.arange(0, self.n_unit, self.up_factor)
+        # Computing SVD for each template.
+        self.compress_templates()
+        # Compute pairwise convolution of filters
+        self.pairwise_filter_conv()
+        # compute norm of templates
+        self.norm = np.zeros([self.orig_n_unit, 1], dtype=np.float32)
+        for i in range(self.orig_n_unit):
+            self.norm[i] = np.sum(
+                    np.square(self.temps[:, self.vis_chan[:, i], i]))
+        # Setting up data properties
+        self.keep_iterations = keep_iterations
+        self.update_data(data)
+        self.dec_spike_train = np.zeros([0, 2], dtype=np.int32)
+        # Energey reduction for assigned spikes.
+        self.dist_metric = np.array([])
+        # Single time preperation for high resolution matches
+        # matching indeces of peaks to indices of upsampled templates
+        factor = self.up_factor
+        radius = factor // 2 + factor % 2
+        self.up_window = np.arange(-radius - 1, radius + 1)[:, None]
+        self.up_window_len = len(self.up_window)
+        off = (factor + 1) % 2
+        # Indices of single time window the window around peak after upsampling
+        self.zoom_index = (radius + 1) * factor + np.arange(-factor // 2, radius)
+        peak_to_template_idx = np.append(
+                np.arange(radius + off, factor),
+                np.arange(radius + off))
+        self.peak_to_template_idx = np.pad(
+                peak_to_template_idx, (1, 0), 'edge')
+        if off:
+            self.peak_to_template_idx[0] -= 1
+        peak_time_jitter = np.array([1, 0]).repeat(radius)
+        peak_time_jitter[radius - 1] = 0
+        self.peak_time_jitter = np.pad(peak_time_jitter, (1, 0), 'edge')
+        # Refractory Perios Setup.
+        self.refrac_radius = refrac_period
+        # Account for upsampling window so that np.inf does not fall into the
+        # window around peak for valid spikes.
+        self.adjusted_refrac_radius = max(
+                1, self.refrac_radius - self.up_factor // 2)
+
+    def update_data(self, data):
+        """Updates the data for the deconv to be run on with same templates."""
+        self.data = data.astype(np.float32)
+        self.data_len = data.shape[0]
+        # Computing SVD for each template.
+        self.obj_len = self.data_len + self.n_time - 1
+        self.dot = np.zeros(
+                [self.orig_n_unit, self.obj_len],
+                dtype=np.float32)
+        # Indicator for computation of the objective.
+        self.obj_computed = False
+        # Resulting recovered spike train.
+        self.dec_spike_train = np.zeros([0, 2], dtype=np.int32)
+        self.dist_metric = np.array([])
+        self.iter_spike_train = []
+
+    def visible_chans(self):
+        if self.vis_chan is None:
+            a = np.max(self.temps, axis=0) - np.min(self.temps, 0)
+            self.vis_chan = a > self.vis_su_threshold
+        return self.vis_chan
+
+    def template_overlaps(self):
+        """Find pairwise units that have overlap between."""
+        vis = self.vis_chan.T
+        self.unit_overlap = np.sum(
+            np.logical_and(vis[:, None, :], vis[None, :, :]), axis=2)
+        self.unit_overlap = self.unit_overlap > 0
+        self.unit_overlap = np.repeat(self.unit_overlap, self.up_factor, axis=0)
+
+    def spatially_mask_templates(self):
+        """Spatially mask templates so that non visible channels are zero."""
+        idx = np.logical_xor(
+                np.ones(self.temps.shape, dtype=bool), self.vis_chan)
+        self.temps[idx] = 0.
+
+    def compress_templates(self):
+        """Compresses the templates using SVD and upsample temporal compoents."""
+        self.temporal, self.singular, self.spatial = np.linalg.svd(
+            np.transpose(np.flipud(self.temps), (2, 0, 1)))
+        # Keep only the strongest components
+        self.temporal = self.temporal[:, :, :self.approx_rank]
+        self.singular = self.singular[:, :self.approx_rank]
+        self.spatial = self.spatial[:, :self.approx_rank, :]
+        # Upsample the temporal components of the SVD
+        # in effect, upsampling the reconstruction of the
+        # templates.
+        if self.up_factor == 1:
+            # No upsampling is needed.
+            self.temporal_up = self.temporal
+            return
+        self.temporal_up = scipy.signal.resample(
+                self.temporal, self.n_time * self.up_factor, axis=1)
+        idx = np.arange(0, self.n_time * self.up_factor, self.up_factor) + np.arange(self.up_factor)[:, None]
+        self.temporal_up = np.reshape(
+                self.temporal_up[:, idx, :], [-1, self.n_time, self.approx_rank]).astype(np.float32)
+
+    def pairwise_filter_conv(self):
+        """Computes pairwise convolution of templates using SVD approximation."""
+        conv_res_len = self.n_time * 2 - 1
+        self.pairwise_conv = []
+        for i in range(self.n_unit):
+            self.pairwise_conv.append(None)
+        available_upsampled_units = np.unique(self.up_up_map)
+        for unit2 in available_upsampled_units:
+            # Set up the unit2 conv all overlaping original units.
+            n_overlap = np.sum(self.unit_overlap[unit2, :])
+            self.pairwise_conv[unit2] = np.zeros([n_overlap, conv_res_len], dtype=np.float32)
+            orig_unit = unit2 // self.up_factor
+            masked_temp = np.flipud(np.matmul(
+                    self.temporal_up[unit2] * self.singular[orig_unit][None, :],
+                    self.spatial[orig_unit, :, :]))
+            for j, unit1 in enumerate(np.where(self.unit_overlap[unit2, :])[0]):
+                u, s, vh = self.temporal[unit1], self.singular[unit1], self.spatial[unit1] 
+                vis_chan_idx = self.vis_chan[:, unit1]
+
+                mat_mul_res = np.matmul(
+                        masked_temp[:, vis_chan_idx], vh[:self.approx_rank, vis_chan_idx].T)
+                for i in range(self.approx_rank):
+                    self.pairwise_conv[unit2][j, :] += np.convolve(
+                            mat_mul_res[:, i],
+                            s[i] * u[:, i].flatten(), 'full')
+        self.pairwise_conv = np.array(self.pairwise_conv)
+
+    def get_reconstructed_upsampled_templates(self):
+        """Get the reconstructed upsampled versions of the original templates.
+
+        If no upsampling was requested, returns the SVD reconstructed version
+        of the original templates.
+        """
+        rec = np.matmul(
+                self.temporal_up * np.repeat(self.singular, self.up_factor, axis=0)[:, None, :],
+                np.repeat(self.spatial, self.up_factor, axis=0))
+        return np.fliplr(rec).transpose([1, 2, 0])
+
+    def get_sparse_upsampled_templates(self):
+        """Returns the fully upsampled sparse version of the original templates.
+
+        returns:
+        --------
+        Tuple of numpy.ndarray. First element is of shape (t, C, M) is the set
+        updampled shifted templates that have been used in the dynamic
+        upsampling approach. Second is an array of lenght K (number of original
+        units) * maximum upsample factor. Which maps cluster ids that are result
+        of deconvolution to 0,...,M-1 that corresponds to the sparse upsampled
+        templates.
+        """
+        down_sample_idx = np.arange(
+                0, self.n_time * self.up_factor, self.up_factor)
+        down_sample_idx = down_sample_idx + np.arange(
+                0, self.up_factor)[:, None]
+        result = []
+        # Reordering the upsampling. This is done because we upsampled the time
+        # reversed temporal components of the SVD reconstruction of the
+        # templates. This means That the time-reveresed 10x upsampled indices
+        # respectively correspond to [0, 9, 8, ..., 1] of the 10x upsampled of
+        # the original templates.
+        all_temps = []
+        reorder_idx = np.append(
+                np.arange(0, 1),
+                np.arange(self.up_factor - 1, 0, -1))
+        # Sequentialize the number of up_up_map. For instance,
+        # [0, 0, 0, 0, 4, 4, 4, 4, ...] turns to [0, 0, 0, 0, 1, 1, 1, 1, ...].
+        deconv_id_sparse_temp_map = []
+        tot_temps_so_far = 0
+        for i in range(self.orig_n_unit):
+            up_temps = scipy.signal.resample(
+                    self.orig_temps[:, :, i],
+                    self.n_time * self.up_factor)[down_sample_idx, :]
+            up_temps = up_temps.transpose([1, 2, 0])
+            up_temps = up_temps[:, :, reorder_idx]
+            skip = self.up_factor // self.unit_up_factor[i]
+            keep_upsample_idx = np.arange(0, self.up_factor, skip).astype(np.int32)
+            deconv_id_sparse_temp_map.append(np.arange(
+                    self.unit_up_factor[i]).repeat(skip) + tot_temps_so_far)
+            tot_temps_so_far += self.unit_up_factor[i]
+            all_temps.append(up_temps[:, :, keep_upsample_idx])
+
+        deconv_id_sparse_temp_map = np.concatenate(
+                deconv_id_sparse_temp_map, axis=0)
+        return np.concatenate(all_temps, axis=2), deconv_id_sparse_temp_map
+
+    def get_upsampled_templates(self):
+        """Returns the fully upsampled version of the original templates."""
+        down_sample_idx = np.arange(0, self.n_time * self.up_factor, self.up_factor)
+        down_sample_idx = down_sample_idx + np.arange(0, self.up_factor)[:, None]
+        up_temps = scipy.signal.resample(
+                self.orig_temps, self.n_time * self.up_factor)[down_sample_idx, :, :]
+        up_temps = up_temps.transpose(
+            [2, 3, 0, 1]).reshape([self.n_chan, -1, self.n_time]).transpose([2, 0, 1]) 
+        # Reordering the upsampling. This is done because we upsampled the time
+        # reversed temporal components of the SVD reconstruction of the
+        # templates. This means That the time-reveresed 10x upsampled indices
+        # respectively correspond to [0, 9, 8, ..., 1] of the 10x upsampled of
+        # the original templates.
+        reorder_idx = np.tile(
+                np.append(
+                    np.arange(0, 1),
+                    np.arange(self.up_factor - 1, 0, -1)),
+                self.orig_n_unit)
+        reorder_idx += np.arange(
+                0, self.up_factor * self.orig_n_unit,
+                self.up_factor).repeat(self.up_factor)
+        return up_temps[:, :, reorder_idx]
+
+    def correct_shift_deconv_spike_train(self):
+        """Get time shift corrected version of the deconvovled spike train.
+
+        This corrected version only applies if you consider getting upsampled
+        templates with get_upsampled_templates() method.
+        """
+        correct_spt = copy.copy(self.dec_spike_train)
+        correct_spt[correct_spt[:, 1] % self.up_factor > 0, 0] += 1
+        return correct_spt
+
+    def compute_objective(self):
+        """Computes the objective given current state of recording."""
+        if self.obj_computed:
+            return self.obj
+        n_rows = self.orig_n_unit * self.approx_rank
+        matmul_result = np.matmul(
+                self.spatial.reshape([n_rows, -1]) * self.singular.reshape([-1, 1]),
+                self.data.T)
+        conv_result = np.zeros(
+                [n_rows, self.data_len + self.n_time - 1], dtype=np.float32)
+        filters = self.temporal.transpose([0, 2, 1]).reshape([n_rows, -1])
+        for i in range(n_rows):
+            conv_result[i, :] = np.convolve(
+                    matmul_result[i, :], filters[i, :], mode='full')
+        for i in range(1, self.approx_rank):
+            conv_result[np.arange(0, n_rows, self.approx_rank), :] +=\
+                    conv_result[np.arange(i, n_rows, self.approx_rank), :]
+        self.obj = 2 * conv_result[np.arange(0, n_rows, self.approx_rank), :] - self.norm
+        # Set indicator to true so that it no longer is run
+        # for future iterations in case subtractions are done
+        # implicitly.
+        self.obj_computed = True
+        return self.obj
+
+    def high_res_peak(self, times, unit_ids):
+        """Finds best matching high resolution template.
+
+        Given an original unit id and the infered spike times
+        finds out which of the shifted upsampled templates of
+        the unit best matches at that time to the residual.
+
+        Parameters:
+        -----------
+        times: numpy.array of numpy.int
+            spike times for the unit.
+        unit_ids: numpy.array of numpy.int
+            Respective to times, id of each spike corresponding
+            to the original units.
+
+        Returns:
+        --------
+            tuple in the form of (numpy.array, numpy.array, numpy.array)
+            respectively the offset of shifted templates and a necessary time
+            shift to correct the spike time, and the index of spike times that
+            do not violate refractory period.
+        """
+        if self.up_factor == 1 or len(times) < 1:
+            return 0, 0, range(len(times))
+        idx = times + self.up_window
+        peak_window = self.obj[unit_ids, idx]
+        # Find times that the window around them do not inlucde np.inf.
+        # In other words do not violate refractory period.
+        invalid_idx = np.logical_or(
+            np.isinf(peak_window[0, :]), np.isinf(peak_window[-1, :]))
+        # Turn off the invlaid units for next iterations.
+        turn_off_idx = times[invalid_idx] + np.arange(
+                - self.refrac_radius, 1)[:, None]
+        self.obj[unit_ids[invalid_idx], turn_off_idx] = - np.inf
+        valid_idx = np.logical_not(invalid_idx)
+        peak_window = peak_window[:, valid_idx]
+        if peak_window.shape[1]  == 0:
+            return np.array([]), np.array([]), valid_idx 
+        high_resolution_peaks = scipy.signal.resample(
+                peak_window, self.up_window_len * self.up_factor, axis=0)
+        shift_idx = np.argmax(
+                high_resolution_peaks[self.zoom_index, :], axis=0)
+        return self.peak_to_template_idx[shift_idx], self.peak_time_jitter[shift_idx], valid_idx
+
+    def find_peaks(self):
+        """Finds peaks in subtraction differentials of spikes."""
+        max_across_temp = np.max(self.obj, axis=0)
+        spike_times = scipy.signal.argrelmax(
+                max_across_temp, order=self.refrac_radius)[0]
+        spike_times = spike_times[max_across_temp[spike_times] > self.threshold]
+        dist_metric = max_across_temp[spike_times]
+        # TODO(hooshmand): this requires a check of the last element(s)
+        # of spike_times only not of all of them since spike_times
+        # is sorted already.
+        valid_idx = spike_times < self.data_len - self.n_time
+        dist_metric = dist_metric[valid_idx]
+        spike_times = spike_times[valid_idx]
+        # Upsample the objective and find the best shift (upsampled)
+        # template.
+        spike_ids = np.argmax(self.obj[:, spike_times], axis=0)
+        upsampled_template_idx, time_shift, valid_idx = self.high_res_peak(
+                spike_times, spike_ids)
+        # The spikes that had NAN in the window and could not be updampled
+        # should fall-back on default value.
+        spike_ids *= self.up_factor
+        if np.sum(valid_idx) > 0:
+            spike_ids[valid_idx] += upsampled_template_idx
+            spike_times[valid_idx] -= time_shift
+        # Note that we shift the discovered spike times from convolution
+        # Space to actual raw voltate space by subtracting self.n_time
+        result = np.append(
+            spike_times[:, None] - self.n_time + 1,
+            spike_ids[:, None], axis=1)
+
+        return result, dist_metric[valid_idx]
+
+    def enforce_refractory(self, spike_train):
+        """Enforces refractory period for units."""
+        window = np.arange(- self.adjusted_refrac_radius, self.adjusted_refrac_radius)
+        n_spikes = spike_train.shape[0]
+        win_len = len(window)
+        # The offset self.n_time - 1 is necessary to revert the spike times
+        # back to objective function indices which is the result of convoultion
+        # operation.
+        time_idx = (spike_train[:, 0:1] + self.n_time - 1) + window
+        # Re-adjust cluster id's so that they match
+        # with the original templates
+        unit_idx = spike_train[:, 1:2] // self.up_factor
+        self.obj[unit_idx, time_idx[:, 1:-1]] = - np.inf
+
+    def enforce_regularization(self, spike_train):
+        """Adds sparsity regularization term to the objective function.
+
+        Assuming that rates
+        """
+        cosnt = 10
+        self.obj -= spike_train.shape[0] * const
+
+    def subtract_spike_train(self, spt):
+        """Substracts a spike train from the original spike_train."""
+        present_units = np.unique(spt[:, 1])
+        for i in present_units:
+            conv_res_len = self.n_time * 2 - 1
+            unit_sp = spt[spt[:, 1] == i, :]
+            spt_idx = np.arange(0, conv_res_len) + unit_sp[:, :1] 
+            # Grid idx of subset of channels and times
+            unit_idx = self.unit_overlap[i]
+            idx = np.ix_(unit_idx, spt_idx.ravel())
+            self.obj[idx] -= np.tile(
+                    2 * self.pairwise_conv[self.up_up_map[i]], len(unit_sp))
+
+        self.enforce_refractory(spt)
+        # self.enforce_regularization(spt)
+
+    def get_iteration_spike_train(self):
+        return self.iter_spike_train
+
+    def run(self, max_iter):
+        ctr = 0
+        tot_max = np.inf
+        self.compute_objective()
+        while tot_max > self.threshold and ctr < max_iter:
+            spt, dist_met = self.find_peaks()
+            print "Iteration {0} Found {1} spikes with {2:.2f} energy reduction.".format(
+                ctr, spt.shape[0], np.sum(dist_met))
+            if len(spt) == 0:
+                break
+            self.dec_spike_train = np.append(self.dec_spike_train, spt, axis=0)
+            self.subtract_spike_train(spt)
+            if self.keep_iterations:
+                self.iter_spike_train.append(spt)
+            self.dist_metric = np.append(self.dist_metric, dist_met)
+            ctr += 1
+        return self.dec_spike_train, self.dist_metric
+

--- a/src/yass/deconvolve/template.py
+++ b/src/yass/deconvolve/template.py
@@ -1,0 +1,144 @@
+"""Class that provides some basic functions of wave forms."""
+
+import numpy as np
+from scipy.interpolate import interp1d
+from scipy.spatial.distance import pdist, squareform
+
+
+class Geometry(object):
+    """Geometry Object for finidng closest channels."""
+    def __init__(self, geometry):
+        self.geom = geometry
+        self.pdist = squareform(pdist(geometry))
+
+    def neighbors(self, channel, size):
+        return np.argsort(self.pdist[channel, :])[:size]
+
+
+class WaveForms(object):
+
+    def __init__(self, wave_forms, geometry=None):
+        """Sets up and computes properties of wave forms.
+
+        params:
+        -------
+        wave_forms: numpy.ndarray
+            Shape of wave forms is (N, C, t). N is total number of wave forms
+            C is number of channels and t is number of time points.
+        geometry: numpy.ndarray
+            Geometry of the probe that the wave forms belong to. Array has shape
+            (N, 2) the coordinates of the probe.
+        """
+        self.wave_forms = wave_forms
+        self.n_unit, self.n_channel, self.n_time = self.wave_forms.shape
+
+    def __getitem__(self, key):
+        return self.wave_forms.__getitem__(key)
+
+    def svd_reconstruct(self, temp_id, rank=3):
+        """Reconstruct the wave forms by given id using SVD.
+
+        params:
+        -------
+        temp_id: int or np.array
+            template id(s) of the template to be reconstructed.
+        rank: int
+            Rank of the SVD reconstruction.
+
+        returns:
+        --------
+        numpy.ndarray of shape (C, t) or (n, C, t) which is the SVD
+        reconstructed version of the given wave forms.
+        """
+        u, h, v = np.linalg.svd(self.wave_forms[temp_id, :, :])
+        if len(u.shape) == 3:
+            # Multiple units at a time.
+            return np.matmul(u[:, :, :rank] * h[:, None, :rank], v[:, :rank, :])
+
+        return np.matmul(u[:, :rank] * h[:rank], v[:rank, :])
+
+    def vis_chan(self, threshold=2.):
+        """Computes boolean visibility matrix of the wave forms.
+
+        params:
+        -------
+        threshold: float
+            Threshold of visibility in terms of standard unit (SU).
+
+        return:
+        -------
+        numpy.ndarray of shape (N, C).
+        """
+        return self.wave_forms.ptp(axis=-1) > threshold
+
+    def ptp(self):
+        """Returns ptp of wave forms in standard units.
+
+        returns:
+        --------
+        numpy.array of size N.
+        """
+        return self.wave_forms.ptp(axis=-1).max(axis=-1)
+
+    def get_shifted_waveforms(self, shifts, clip_value):
+        """Get shifted viersions of the wave forms given the amount of shifts.
+
+        params:
+        -------
+        shifts: float or np.array.float
+            List of shifts that indicated how much has to change.
+
+        returns:
+        --------
+        numpy.ndarray of shifted wave forms.
+        """
+        unit_time_window = np.arange(
+                self.n_time - 2 * clip_value) + shifts[:, None]
+        default_range = np.arange(self.n_time - 2 * clip_value)
+        sub_shifts = shifts - np.floor(shifts)
+        shifts = np.floor(shifts).astype(np.int)
+
+        def sub(i, shift, sub=None):
+            if sub is None:
+                return self.wave_forms[i, :, default_range + shift]
+            return sub(i, shift) * sub + sub(i, shift + 1) * (1 - sub)
+
+        if sub_shifts.sum() > 0.:
+            # Linear interpolation.
+            np.array(
+                [sub(i, s, sub_shifts[i]) for i, s in enumerate(
+                    shifts)]).transpose([0, 2, 1])
+
+        return np.array(
+                [sub(i, s) for i, s in enumerate(shifts)]).transpose([0, 2, 1])
+
+    def align(self, ref_wave_form=None, jitter=3, upsample=1):
+        """Aligns all the wave forms to the reference wave form.
+
+        params:
+        -------
+        jitter: int
+            How much jitter per wave form in subsample time is allowed.
+        upsample: int
+            Factor for interpolation of signals.
+        """
+        if ref_wave_form is None:
+            ref_wave_form = self.wave_forms.mean(axis=0)
+
+        ptp = ref_wave_form.ptp(axis=1)
+        max_chan = ptp.argmax()
+
+        wf = self.wave_forms
+        if upsample > 1:
+            x_range = np.arange(0, self.n_time)
+            f = interp1d(x_range, self.wave_forms)
+            wf = f(x_range[:-1] + np.arange(0, 1, 1./upsample))
+
+        # Upsample these guys
+        ref = ref_wave_form[max_chan, jitter:-jitter]
+        idx = np.arange(
+                self.n_time - 2 * jitter) + np.arange(2 * jitter)[:, None]
+        all_shifts = self.wave_forms[:, max_chan, idx]
+        best_shift_idx = np.square(
+                all_shifts - ref).sum(axis=-1).argmin(axis=-1)
+        return self.get_shifted_waveforms(best_shift_idx, clip_value=jitter)

--- a/src/yass/pipeline.py
+++ b/src/yass/pipeline.py
@@ -34,6 +34,8 @@ from yass.util import (load_yaml, save_metadata, load_logging_config_file,
                        human_readable_time)
 from yass.explore import RecordingExplorer
 from yass.threshold import dimensionality_reduction as dim_red
+from yass.deconvolve.collision import collision_templates
+from yass.cluster.cluster import binary_reader_waveforms
 
 
 def run(config, logger_level='INFO', clean=False, output_dir='tmp/',
@@ -171,6 +173,25 @@ def run(config, logger_level='INFO', clean=False, output_dir='tmp/',
         ************** DECONVOLUTION *****************
         **********************************************
     '''
+    # detect and remove collision templates
+    # wrapper function for getting waveforms that is passed to collision
+    # detection
+    def get_unit_wave_forms(uid):
+        spt = spike_train_cluster[spike_train_cluster[:, 1] == uid, 0] - 81//2
+        spikes_ =  binary_reader_waveforms(
+                standardized_filename=standardized_path,
+                n_channels=standardized_params['n_channels'],
+                n_times=81, spikes=spt,
+                channels=None)[0].transpose([0, 2, 1])
+        return spikes_
+
+    collision_units = collision_templates(
+            templates_cluster.transpose([0, 2, 1]),
+            get_unit_wave_forms).astype(np.int)
+
+    logger.info('Collision units: {} units removed.'.format(
+        len(collision_units)))
+    templates_cluster = templates_cluster[collision_units, :, :]
 
     # run deconvolution
     start=time.time()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def path_to_sample_pipeline_folder():
 def path_to_standardized_data():
     return os.path.join(PATH_TO_RETINA_DIR,
                         'sample_pipeline_output', 'preprocess',
-                        'standardized.bin')
+                        'standarized.bin')
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def path_to_sample_pipeline_folder():
 def path_to_standardized_data():
     return os.path.join(PATH_TO_RETINA_DIR,
                         'sample_pipeline_output', 'preprocess',
-                        'standarized.bin')
+                        'standardized.bin')
 
 
 @pytest.fixture()


### PR DESCRIPTION
Added some tools to detect collision templates using MAD statistics and reconstruction of templates using themselves.

- yass/deconvolve/collision.py
- yass/deconvolve/optimized_match_pursuit.py
- yass/deconvolve/template.py

Function collision_templates(templates, get_unit_spike_fun) gets a set of templates and a function that retrieves spikes from unit given id of unit get_unit_spike_fun(uid). It returns a list of unit ids that are classified as collision templates.